### PR TITLE
Fixed cli-table depencency and Litmus.getId() edge case

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ If you're having issues with Litmus taking forever to load a test or the title o
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 
 ## Release History
+0.1.6 - Fixed a bug with cli-table dependency and on duplicate tests' subjects.  
 0.1.5 - Added more logging information about a test. Fixes [#16](https://github.com/yargalot/Email-Builder/issues/16)  
 0.1.4 - Added options.delay  
 0.1.3 - Add +1 to each duplicate title   

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-litmus",
   "description": "Send email tests to Litmus",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "homepage": "https://github.com/jeremypeter/grunt-litmus",
   "author": "Jeremy Peter <jeremywpeter@gmail.com> (http://www.jeremypeterdesigns.com)",
   "repository": {
@@ -28,8 +28,7 @@
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.1",
-    "cli-table": "~0.3.0"
+    "grunt": "~0.4.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.2"
@@ -45,7 +44,8 @@
     "cheerio": "~0.13.1",
     "nodemailer": "~0.6.0",
     "request": "~2.33.0",
-    "async": "~0.2.9"
+    "async": "~0.2.9",
+    "cli-table": "~0.3.0"
   },
   "directories": {
     "example": "example",

--- a/tasks/lib/litmus.js
+++ b/tasks/lib/litmus.js
@@ -18,7 +18,7 @@ Litmus.prototype.initVars = function() {
   this.reqObj = {
     auth: {
       user: this.options.username || '',
-      pass: this.options.password || ''      
+      pass: this.options.password || ''
     }
   };
 };
@@ -63,7 +63,7 @@ Litmus.prototype.getId = function(body) {
       });
 
   if($matchedName.length){
-    id = $matchedName.parent().children('id').text();
+    id = $matchedName.first().parent().children('id').text();
   }
 
   return id;
@@ -168,7 +168,7 @@ Litmus.prototype.logHeaders = function(err, res, body) {
     console.log(key.toUpperCase().bold + ': ' + headers[key]);
   });
 
-  console.log('---------------------\n' + body); 
+  console.log('---------------------\n' + body);
 
   if(status > 199 && status < 300){
     this.logSuccess('Test sent!');
@@ -184,7 +184,7 @@ Litmus.prototype.mailNewVersion = function(err, res, body) {
   if(err){ throw err; }
 
   var $ = cheerio.load(body),
-      guid = $('url_or_guid').text(); 
+      guid = $('url_or_guid').text();
 
   mail({
       from: 'no-reply@test.com',


### PR DESCRIPTION
Hi,

i've finally found some spare time to integrate your plugin with my [boilerplate](https://github.com/dwightjack/grunt-email-boilerplate). 

Great work! Anyway I've noticed a couple of problems:

1) `cli-table` was in the `devDependencies` section, which is not downloaded when installing the plugin. I've moved it to `dependencies`.

2) I had an edge case with two existing tests having the same subject. By sending another test (again, with the  same subject), the `Litmus.getId()` was retrieving two test nodes. Ence the returned value was {testid1}{testid2}.
I've solved the issue changing the line:

``` js
$matchedName.parent().children('id').text();
```

to

``` js
$matchedName.first().parent().children('id').text();
```

I've already changed the patch version of the package and updated the readme.
